### PR TITLE
Add tests for smartFetch errors in catch block

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,9 +1,5 @@
 {
   "parser": "@typescript-eslint/parser",
-  "plugins": [
-    "@typescript-eslint"
-  ],
-  "extends": [
-    "plugin:@typescript-eslint/recommended"
-  ]
+  "plugins": ["@typescript-eslint"],
+  "extends": ["plugin:@typescript-eslint/recommended"]
 }

--- a/lib/fetch/__tests__/smartfetch.test.ts
+++ b/lib/fetch/__tests__/smartfetch.test.ts
@@ -80,4 +80,34 @@ describe('SmartFetch http client wrapper', () => {
     expect(shouldNOTError).toBeInstanceOf(Ok)
 
   })
+
+  it('handles unexpected/critical errors', async () => {
+    const { smartFetch } = SmartFetch
+
+    fetchMock.mockRejectOnce(new Error('Testing when something breaks'))
+    const shouldCatch = await smartFetch(SmartFetch.RequestMethods.GET, '/bad-route')
+
+    expect(shouldCatch).toBeInstanceOf(Err)
+    expect((shouldCatch.unwrapErr() as Error).message).toBe('Testing when something breaks')
+  })
+
+  it('catches errors from broken filter functions', async () => {
+    const { smartFetch } = SmartFetch
+
+    function shouldThrow(res: unknown) {
+      throw new Error('[ smartFetch ] Something went very wrong')
+      if (res) {
+        return true
+      }
+      return false
+    }
+
+    fetchMock.mockResponseOnce(JSON.stringify({ error: 'unrecoverable' }), { status: 200, headers: { 'content-type': 'application/json' } })
+    const res = await smartFetch<{ error: string }, Error>(SmartFetch.RequestMethods.GET, '/bad-route', null, {
+      shouldThrow
+    })
+
+    expect(res).toBeInstanceOf(Err)
+    expect((res.unwrapErr() as Error).message).toBe('[ smartFetch ] Something went very wrong')
+  })
 })

--- a/lib/fetch/__tests__/smartfetch.test.ts
+++ b/lib/fetch/__tests__/smartfetch.test.ts
@@ -89,26 +89,28 @@ describe('SmartFetch http client wrapper', () => {
     const shouldCatch = await smartFetch(SmartFetch.RequestMethods.GET, '/bad-route')
 
     expect(shouldCatch).toBeInstanceOf(Err)
-    expect((shouldCatch.unwrapErr() as Error).message).toBe('Testing when something breaks')
+    expect((shouldCatch.unwrapErr()).message).toBe('Testing when something breaks')
   })
 
   it('catches errors from broken filter functions', async () => {
     const { smartFetch } = SmartFetch
+    class CustomError extends Error { }
 
     function shouldThrow(res: unknown) {
-      throw new Error('[ smartFetch ] Something went very wrong')
+      throw new CustomError('[ smartFetch ] Something went very wrong')
       if (res) {
         return true
       }
       return false
     }
 
+
     fetchMock.mockResponseOnce(JSON.stringify({ error: 'unrecoverable' }), { status: 200, headers: { 'content-type': 'application/json' } })
-    const res = await smartFetch<{ error: string }, Error>(SmartFetch.RequestMethods.GET, '/bad-route', null, {
+    const res = await smartFetch<{ error: string }, CustomError>(SmartFetch.RequestMethods.GET, '/bad-route', null, {
       shouldThrow
     })
 
     expect(res).toBeInstanceOf(Err)
-    expect((res.unwrapErr() as Error).message).toBe('[ smartFetch ] Something went very wrong')
+    expect((res.unwrapErr()).message).toBe('[ smartFetch ] Something went very wrong')
   })
 })

--- a/lib/fetch/__tests__/smartfetch.test.ts
+++ b/lib/fetch/__tests__/smartfetch.test.ts
@@ -56,7 +56,8 @@ describe('SmartFetch http client wrapper', () => {
     fetchMock.mockResponseOnce(JSON.stringify({ error: 'Message here' }), { status: 200, headers: { 'content-type': 'application/json' } })
 
     // Mock example to catch any response with an 'error' key, but only if 'error' is not an empty string
-    function shouldThrow(res: { [index: string]: unknown }) {
+    function shouldThrow(res: { [index: string]: unknown } | Error) {
+      if (res instanceof Error) return true
       if (Object.keys(res).includes('error') && res.error !== '') {
         return true
       }

--- a/lib/fetch/index.ts
+++ b/lib/fetch/index.ts
@@ -27,7 +27,7 @@ export function getSmartFetchConfig(): GlobalConfig {
 }
 
 
-export async function smartFetch<T, E>(method: RequestMethods, url: string, body?: unknown, config: GlobalConfig<T | E> = {}): Promise<Result<T, E>> {
+export async function smartFetch<T, E extends Error>(method: RequestMethods, url: string, body?: unknown, config: GlobalConfig<T | E> = {}): Promise<Result<T, E>> {
   const { shouldThrow, ...local } = config
 
   // local will always override global unless otherwise allowed in the future

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,6 @@
 export declare type Nullable<T> = T | null;
 export declare type Optional<T> = T | undefined;
 
-
-export * as Sync from './sync'
-export * as Async from './async'
+export * as Sync from "./sync";
+export * as Async from "./async";
+export * as SmartFetch from "./fetch";


### PR DESCRIPTION
This should add a little more solid testing coverage for `smartFetch`. Now all three possible return areas are covered :)

Also slightly breaking change: `smartFetch` now expects `E` to extend `Error`