### PR TITLE
linting + prettier, fix `smartFetch` breaking when there's no window global

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/lib/fetch/__tests__/__snapshots__/smartFetchNoDOM.test.ts.snap
+++ b/lib/fetch/__tests__/__snapshots__/smartFetchNoDOM.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SmartFetch no DOM still catches errors without breaking 1`] = `
+Err {
+  "type": "Err",
+  "value": [FetchError: invalid json response body at  reason: Unexpected end of JSON input],
+}
+`;
+
+exports[`SmartFetch no DOM still returns okay values without breaking 1`] = `
+Ok {
+  "type": "Ok",
+  "value": Object {
+    "data": "here",
+  },
+}
+`;

--- a/lib/fetch/__tests__/smartFetchNoDOM.test.ts
+++ b/lib/fetch/__tests__/smartFetchNoDOM.test.ts
@@ -1,13 +1,34 @@
-import { enableFetchMocks } from "jest-fetch-mock";
+import { Err, Ok } from '@dukeferdinand/ts-results';
+import { enableFetchMocks } from 'jest-fetch-mock';
 enableFetchMocks();
 
-import * as SmartFetch from "..";
+import * as SmartFetch from '..';
 
 const { smartFetch, RequestMethods } = SmartFetch;
 
-describe("SmartFetch no DOM", () => {
-  it("still functions without breaking", async () => {
-    const res = await smartFetch(RequestMethods.GET, "/");
-    expect(true);
+/**
+ * Quick description of this file:
+ * "no DOM" is intended to mean anywhere that doesn't have access to a `window` key.
+ * You can still use the config param when passing global config options to any given fetch request.
+ * This will vary WILDLY from library to library, so just look up your preferred SSR state or context docs
+ */
+
+describe('SmartFetch no DOM', () => {
+  it('still catches errors without breaking', async () => {
+    const res = await smartFetch(RequestMethods.GET, '/');
+
+    expect(res).toBeInstanceOf(Err);
+    expect(res).toMatchSnapshot();
+  });
+
+  it('still returns okay values without breaking', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ data: 'here' }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+    const res = await smartFetch(RequestMethods.GET, '/');
+
+    expect(res).toBeInstanceOf(Ok);
+    expect(res).toMatchSnapshot();
   });
 });

--- a/lib/fetch/__tests__/smartFetchNoDOM.test.ts
+++ b/lib/fetch/__tests__/smartFetchNoDOM.test.ts
@@ -1,0 +1,13 @@
+import { enableFetchMocks } from "jest-fetch-mock";
+enableFetchMocks();
+
+import * as SmartFetch from "..";
+
+const { smartFetch, RequestMethods } = SmartFetch;
+
+describe("SmartFetch no DOM", () => {
+  it("still functions without breaking", async () => {
+    const res = await smartFetch(RequestMethods.GET, "/");
+    expect(true);
+  });
+});

--- a/lib/fetch/__tests__/smartfetch.test.ts
+++ b/lib/fetch/__tests__/smartfetch.test.ts
@@ -3,114 +3,152 @@
  */
 
 // I'm using a jsdom environment here as I'm explicitly testing browser functionality vs node stuff for now
-import { Err, Ok } from '@dukeferdinand/ts-results'
-import { enableFetchMocks } from 'jest-fetch-mock'
-enableFetchMocks()
+import { Err, Ok } from '@dukeferdinand/ts-results';
+import { enableFetchMocks } from 'jest-fetch-mock';
+enableFetchMocks();
 
-import * as SmartFetch from '..'
+import * as SmartFetch from '..';
 
 describe('SmartFetch config utils', () => {
   beforeEach(() => {
     SmartFetch.initSmartFetch({
-      baseUrl: 'https://google.com'
-    })
-  })
+      baseUrl: 'https://google.com',
+    });
+  });
   describe('when initializing', () => {
     it('sets __SMART_FETCH_CONFIG__', () => {
-      expect(window.__SMART_FETCH_CONFIG__?.baseUrl).toBe('https://google.com')
-    })
+      expect(window.__SMART_FETCH_CONFIG__?.baseUrl).toBe('https://google.com');
+    });
     it('overwrites previous config if called again', () => {
       SmartFetch.initSmartFetch({
-        baseUrl: 'https://twitch.tv'
-      })
-      expect(window.__SMART_FETCH_CONFIG__?.baseUrl).toBe('https://twitch.tv')
-    })
-  })
+        baseUrl: 'https://twitch.tv',
+      });
+      expect(window.__SMART_FETCH_CONFIG__?.baseUrl).toBe('https://twitch.tv');
+    });
+  });
 
   describe('when getting', () => {
     it('correctly retrieves __SMART_FETCH_CONFIG__', () => {
-      const conf = SmartFetch.getSmartFetchConfig()
-      expect(conf?.baseUrl).toBe('https://google.com')
-    })
-  })
-})
+      const conf = SmartFetch.getSmartFetchConfig();
+      expect(conf?.baseUrl).toBe('https://google.com');
+    });
+  });
+});
 
 describe('SmartFetch http client wrapper', () => {
   it('returns good data wrapped in Ok variant', async () => {
-    fetchMock.mockResponse(JSON.stringify({ "ip": "70.113.52.10" }))
+    fetchMock.mockResponse(JSON.stringify({ ip: '70.113.52.10' }));
 
-    const res = await SmartFetch.smartFetch(SmartFetch.RequestMethods.GET, '/fake-ip-route?format=json')
-    expect(res).toBeInstanceOf(Ok)
-    expect(res.unwrap()).toEqual({ "ip": "70.113.52.10" })
-  })
+    const res = await SmartFetch.smartFetch(
+      SmartFetch.RequestMethods.GET,
+      '/fake-ip-route?format=json'
+    );
+    expect(res).toBeInstanceOf(Ok);
+    expect(res.unwrap()).toEqual({ ip: '70.113.52.10' });
+  });
 
   it('returns "bad" http statuses as Err variants', async () => {
-    fetchMock.mockResponseOnce(JSON.stringify({ error: 'Message here' }), { status: 500, headers: { 'content-type': 'application/json' } })
-    const res = await SmartFetch.smartFetch(SmartFetch.RequestMethods.GET, '/bad-route')
+    fetchMock.mockResponseOnce(JSON.stringify({ error: 'Message here' }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    });
+    const res = await SmartFetch.smartFetch(
+      SmartFetch.RequestMethods.GET,
+      '/bad-route'
+    );
 
-    expect(res).toBeInstanceOf(Err)
-    expect(res.unwrapErr()).toEqual({ "error": "Message here" })
-  })
+    expect(res).toBeInstanceOf(Err);
+    expect(res.unwrapErr()).toEqual({ error: 'Message here' });
+  });
 
   it('uses shouldThrow to catch any non standard errors', async () => {
-    fetchMock.mockResponseOnce(JSON.stringify({ error: 'Message here' }), { status: 200, headers: { 'content-type': 'application/json' } })
+    fetchMock.mockResponseOnce(JSON.stringify({ error: 'Message here' }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
 
     // Mock example to catch any response with an 'error' key, but only if 'error' is not an empty string
     function shouldThrow(res: { [index: string]: unknown } | Error) {
-      if (res instanceof Error) return true
+      if (res instanceof Error) return true;
       if (Object.keys(res).includes('error') && res.error !== '') {
-        return true
+        return true;
       }
-      return false
+      return false;
     }
 
     // Break because error is not an empty string
-    const shouldError = await SmartFetch.smartFetch(SmartFetch.RequestMethods.GET, '/bad-route', null, {
-      shouldThrow
-    })
+    const shouldError = await SmartFetch.smartFetch(
+      SmartFetch.RequestMethods.GET,
+      '/bad-route',
+      null,
+      {
+        shouldThrow,
+      }
+    );
 
-    expect(shouldError).toBeInstanceOf(Err)
+    expect(shouldError).toBeInstanceOf(Err);
 
     // Specifically allow error key with empty string in this test
-    fetchMock.mockResponseOnce(JSON.stringify({ error: '' }), { status: 200, headers: { 'content-type': 'application/json' } })
+    fetchMock.mockResponseOnce(JSON.stringify({ error: '' }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
 
-    const shouldNOTError = await SmartFetch.smartFetch(SmartFetch.RequestMethods.GET, '/okay-route', null, {
-      shouldThrow
-    })
+    const shouldNOTError = await SmartFetch.smartFetch(
+      SmartFetch.RequestMethods.GET,
+      '/okay-route',
+      null,
+      {
+        shouldThrow,
+      }
+    );
 
-    expect(shouldNOTError).toBeInstanceOf(Ok)
-
-  })
+    expect(shouldNOTError).toBeInstanceOf(Ok);
+  });
 
   it('handles unexpected/critical errors', async () => {
-    const { smartFetch } = SmartFetch
+    const { smartFetch } = SmartFetch;
 
-    fetchMock.mockRejectOnce(new Error('Testing when something breaks'))
-    const shouldCatch = await smartFetch(SmartFetch.RequestMethods.GET, '/bad-route')
+    fetchMock.mockRejectOnce(new Error('Testing when something breaks'));
+    const shouldCatch = await smartFetch(
+      SmartFetch.RequestMethods.GET,
+      '/bad-route'
+    );
 
-    expect(shouldCatch).toBeInstanceOf(Err)
-    expect((shouldCatch.unwrapErr()).message).toBe('Testing when something breaks')
-  })
+    expect(shouldCatch).toBeInstanceOf(Err);
+    expect(shouldCatch.unwrapErr().message).toBe(
+      'Testing when something breaks'
+    );
+  });
 
   it('catches errors from broken filter functions', async () => {
-    const { smartFetch } = SmartFetch
-    class CustomError extends Error { }
+    const { smartFetch } = SmartFetch;
+    class CustomError extends Error {}
 
     function shouldThrow(res: unknown) {
-      throw new CustomError('[ smartFetch ] Something went very wrong')
+      throw new CustomError('[ smartFetch ] Something went very wrong');
       if (res) {
-        return true
+        return true;
       }
-      return false
+      return false;
     }
 
+    fetchMock.mockResponseOnce(JSON.stringify({ error: 'unrecoverable' }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+    const res = await smartFetch<{ error: string }, CustomError>(
+      SmartFetch.RequestMethods.GET,
+      '/bad-route',
+      null,
+      {
+        shouldThrow,
+      }
+    );
 
-    fetchMock.mockResponseOnce(JSON.stringify({ error: 'unrecoverable' }), { status: 200, headers: { 'content-type': 'application/json' } })
-    const res = await smartFetch<{ error: string }, CustomError>(SmartFetch.RequestMethods.GET, '/bad-route', null, {
-      shouldThrow
-    })
-
-    expect(res).toBeInstanceOf(Err)
-    expect((res.unwrapErr()).message).toBe('[ smartFetch ] Something went very wrong')
-  })
-})
+    expect(res).toBeInstanceOf(Err);
+    expect(res.unwrapErr().message).toBe(
+      '[ smartFetch ] Something went very wrong'
+    );
+  });
+});

--- a/lib/fetch/index.ts
+++ b/lib/fetch/index.ts
@@ -1,9 +1,9 @@
-import { err, ok, Result } from "@dukeferdinand/ts-results";
+import { err, ok, Result } from '@dukeferdinand/ts-results';
 
-import { toString } from "../sync";
+import { toString } from '../sync';
 
 export interface GlobalConfig<T = unknown>
-  extends Omit<RequestInit, "body" | "method"> {
+  extends Omit<RequestInit, 'body' | 'method'> {
   baseUrl?: string;
   shouldThrow?: (response: T) => boolean;
 }
@@ -11,11 +11,11 @@ export interface GlobalConfig<T = unknown>
 export type LocalConfig = RequestInit;
 
 export enum RequestMethods {
-  GET = "GET",
-  POST = "POST",
-  DELETE = "DELETE",
-  PUT = "PUT",
-  PATCH = "PATCH",
+  GET = 'GET',
+  POST = 'POST',
+  DELETE = 'DELETE',
+  PUT = 'PUT',
+  PATCH = 'PATCH',
 }
 
 export function initSmartFetch(config: GlobalConfig): void {
@@ -23,7 +23,7 @@ export function initSmartFetch(config: GlobalConfig): void {
 }
 
 export function getSmartFetchConfig(): GlobalConfig {
-  return typeof window !== "undefined" ? window.__SMART_FETCH_CONFIG__ : {};
+  return typeof window !== 'undefined' ? window.__SMART_FETCH_CONFIG__ : {};
 }
 
 export async function smartFetch<T, E extends Error>(

--- a/lib/fetch/index.ts
+++ b/lib/fetch/index.ts
@@ -1,55 +1,65 @@
 import { err, ok, Result } from "@dukeferdinand/ts-results";
 
-import { toString } from '../sync'
+import { toString } from "../sync";
 
-
-export interface GlobalConfig<T = unknown> extends Omit<RequestInit, "body" | "method"> {
+export interface GlobalConfig<T = unknown>
+  extends Omit<RequestInit, "body" | "method"> {
   baseUrl?: string;
-  shouldThrow?: (response: T) => boolean
+  shouldThrow?: (response: T) => boolean;
 }
 
-export type LocalConfig = RequestInit
+export type LocalConfig = RequestInit;
 
 export enum RequestMethods {
-  GET = 'GET',
-  POST = 'POST',
-  DELETE = 'DELETE',
-  PUT = 'PUT',
-  PATCH = 'PATCH'
+  GET = "GET",
+  POST = "POST",
+  DELETE = "DELETE",
+  PUT = "PUT",
+  PATCH = "PATCH",
 }
 
 export function initSmartFetch(config: GlobalConfig): void {
-  window.__SMART_FETCH_CONFIG__ = config
+  window.__SMART_FETCH_CONFIG__ = config;
 }
 
 export function getSmartFetchConfig(): GlobalConfig {
-  return window.__SMART_FETCH_CONFIG__ || {} as GlobalConfig
+  return window.__SMART_FETCH_CONFIG__ || ({} as GlobalConfig);
 }
 
-
-export async function smartFetch<T, E extends Error>(method: RequestMethods, url: string, body?: unknown, config: GlobalConfig<T | E> = {}): Promise<Result<T, E>> {
-  const { shouldThrow, ...local } = config
+export async function smartFetch<T, E extends Error>(
+  method: RequestMethods,
+  url: string,
+  body?: unknown,
+  config: GlobalConfig<T | E> = {}
+): Promise<Result<T, E>> {
+  const { shouldThrow, ...local } = config;
 
   // local will always override global unless otherwise allowed in the future
-  let localConfig: GlobalConfig & RequestInit = { ...window?.__SMART_FETCH_CONFIG__, ...local, method }
+  let localConfig: GlobalConfig & RequestInit = {
+    ...window?.__SMART_FETCH_CONFIG__,
+    ...local,
+    method,
+  };
 
-  if (body) { localConfig = { ...localConfig, body: toString(body) } }
+  if (body) {
+    localConfig = { ...localConfig, body: toString(body) };
+  }
 
   try {
     // Actual fetch call
-    const res = await fetch(url, localConfig)
-    const parsed: T | E = await res.json()
+    const res = await fetch(url, localConfig);
+    const parsed: T | E = await res.json();
 
     // Res isn't a 400, 500, or other custom error
     if (res.ok && !(shouldThrow && shouldThrow(parsed))) {
       // Everything is okay, return okay data
-      return ok(parsed as T)
+      return ok(parsed as T);
     }
 
     // Something went wrong, return Err wrapped data
-    return err<E>(parsed as E)
+    return err<E>(parsed as E);
   } catch (e) {
     // Something broke that was not able to be caught by normal means
-    return err<E>(e)
+    return err<E>(e);
   }
 }

--- a/lib/fetch/index.ts
+++ b/lib/fetch/index.ts
@@ -23,7 +23,7 @@ export function initSmartFetch(config: GlobalConfig): void {
 }
 
 export function getSmartFetchConfig(): GlobalConfig {
-  return window.__SMART_FETCH_CONFIG__ || ({} as GlobalConfig);
+  return typeof window !== "undefined" ? window.__SMART_FETCH_CONFIG__ : {};
 }
 
 export async function smartFetch<T, E extends Error>(
@@ -36,7 +36,7 @@ export async function smartFetch<T, E extends Error>(
 
   // local will always override global unless otherwise allowed in the future
   let localConfig: GlobalConfig & RequestInit = {
-    ...window?.__SMART_FETCH_CONFIG__,
+    ...getSmartFetchConfig(),
     ...local,
     method,
   };


### PR DESCRIPTION
Mostly to fix `smartFetch` breaking when I tried to use it in Next.js as a SSR prop fetcher. Also adds prettier to standardize my dev environments :)