### PR TITLE
Development

### DIFF
--- a/lib/fetch/__tests__/smartFetchNoDOM.test.ts
+++ b/lib/fetch/__tests__/smartFetchNoDOM.test.ts
@@ -14,6 +14,9 @@ const { smartFetch, RequestMethods } = SmartFetch;
  */
 
 describe('SmartFetch no DOM', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
   it('still catches errors without breaking', async () => {
     const res = await smartFetch(RequestMethods.GET, '/');
 
@@ -30,5 +33,39 @@ describe('SmartFetch no DOM', () => {
 
     expect(res).toBeInstanceOf(Ok);
     expect(res).toMatchSnapshot();
+  });
+
+  it('allows global configs to be passed in via `config`', async () => {
+    fetchMock.mockResponse(JSON.stringify({ data: 'not needed' }));
+
+    // Get this from wherever and pass in at the function or service level
+    const globalConfig: SmartFetch.GlobalConfig = {
+      baseUrl: 'https://google.com',
+    };
+
+    await smartFetch(RequestMethods.GET, '/', globalConfig);
+
+    expect(fetchMock).toBeCalled();
+    expect(fetchMock).toBeCalledWith('https://google.com/', { method: 'GET' });
+  });
+
+  it('body and config do not conflict', async () => {
+    fetchMock.mockResponse(JSON.stringify({ data: 'not needed' }));
+
+    // Get this from wherever and pass in at the function or service level
+    const globalConfig: SmartFetch.GlobalConfig = {
+      baseUrl: 'https://google.com',
+    };
+
+    await smartFetch(RequestMethods.GET, '/', {
+      ...globalConfig,
+      body: { test: '' },
+    });
+
+    expect(fetchMock).toBeCalled();
+    expect(fetchMock).toBeCalledWith('https://google.com/', {
+      body: '{"test":""}',
+      method: 'GET',
+    });
   });
 });

--- a/lib/fetch/__tests__/smartfetch.test.ts
+++ b/lib/fetch/__tests__/smartfetch.test.ts
@@ -36,6 +36,55 @@ describe('SmartFetch config utils', () => {
 });
 
 describe('SmartFetch http client wrapper', () => {
+  beforeEach(() => {
+    fetchMock.mockClear();
+  });
+  it('pulls global config when window is available and local config not set', () => {
+    const { smartFetch, RequestMethods } = SmartFetch;
+    fetchMock.mockResponse(JSON.stringify({ data: 'not-needed' }));
+
+    // Global config
+    SmartFetch.initSmartFetch({
+      baseUrl: 'https://google.com',
+    });
+    smartFetch(RequestMethods.GET, '/');
+
+    expect(fetchMock).toBeCalled();
+    expect(fetchMock).toBeCalledWith('https://google.com/', {
+      method: 'GET',
+    });
+  });
+
+  it('overrides global config with local when set', () => {
+    const { smartFetch, RequestMethods } = SmartFetch;
+    fetchMock.mockResponse(JSON.stringify({ data: 'not-needed' }));
+
+    // Global config
+    SmartFetch.initSmartFetch({
+      baseUrl: 'https://google.com',
+    });
+    smartFetch(RequestMethods.GET, '/', { baseUrl: 'https://twitter.com' });
+
+    expect(fetchMock).toBeCalled();
+    expect(fetchMock).toBeCalledWith('https://twitter.com/', {
+      method: 'GET',
+    });
+  });
+
+  it('handles no baseUrl being set', () => {
+    const { smartFetch, RequestMethods } = SmartFetch;
+    fetchMock.mockResponse(JSON.stringify({ data: 'not-needed' }));
+
+    // Global config
+    SmartFetch.initSmartFetch();
+    smartFetch(RequestMethods.GET, '/');
+
+    expect(fetchMock).toBeCalled();
+    expect(fetchMock).toBeCalledWith('/', {
+      method: 'GET',
+    });
+  });
+
   it('returns good data wrapped in Ok variant', async () => {
     fetchMock.mockResponse(JSON.stringify({ ip: '70.113.52.10' }));
 
@@ -80,7 +129,6 @@ describe('SmartFetch http client wrapper', () => {
     const shouldError = await SmartFetch.smartFetch(
       SmartFetch.RequestMethods.GET,
       '/bad-route',
-      null,
       {
         shouldThrow,
       }
@@ -97,7 +145,6 @@ describe('SmartFetch http client wrapper', () => {
     const shouldNOTError = await SmartFetch.smartFetch(
       SmartFetch.RequestMethods.GET,
       '/okay-route',
-      null,
       {
         shouldThrow,
       }
@@ -140,7 +187,6 @@ describe('SmartFetch http client wrapper', () => {
     const res = await smartFetch<{ error: string }, CustomError>(
       SmartFetch.RequestMethods.GET,
       '/bad-route',
-      null,
       {
         shouldThrow,
       }

--- a/lib/fetch/__tests__/smartfetch.test.ts
+++ b/lib/fetch/__tests__/smartfetch.test.ts
@@ -86,14 +86,14 @@ describe('SmartFetch http client wrapper', () => {
   });
 
   it('returns good data wrapped in Ok variant', async () => {
-    fetchMock.mockResponse(JSON.stringify({ ip: '70.113.52.10' }));
+    fetchMock.mockResponse(JSON.stringify({ ip: '10.0.1.1' }));
 
     const res = await SmartFetch.smartFetch(
       SmartFetch.RequestMethods.GET,
       '/fake-ip-route?format=json'
     );
     expect(res).toBeInstanceOf(Ok);
-    expect(res.unwrap()).toEqual({ ip: '70.113.52.10' });
+    expect(res.unwrap()).toEqual({ ip: '10.0.1.1' });
   });
 
   it('returns "bad" http statuses as Err variants', async () => {


### PR DESCRIPTION
Hopefully the last update to `smartFetch` for a while... This one makes it ACTUALLY WORK and use the config values passed in.

Slightly breaking as the body param is now expected to be part of the `config` object for tidying things up. You can now have something like this work:

```ts

smartFetch(RequestMethods.GET, '/', { baseUrl: 'new-domain.dev' })
```
vs the old way:
```ts
smartFetch(RequestMethods.GET, '/', null, { baseUrl: 'new-domain.dev' })
```
